### PR TITLE
Emacs: Add support for setting Emacs fg and bg

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
     * [i3](#i3)
     * [rofi](#rofi)
     * [vim](#vim)
+    * [Emacs](#emacs)
     * [polybar](#polybar)
     * [iTerm2](#iterm2)
     * [Shell Variables](#shell-variables)
@@ -212,6 +213,10 @@ Plug 'dylanaraps/wal'
 
 colorscheme wal
 ```
+
+### Emacs
+
+Install [this package](https://github.com/cqql/xresources-theme), which will make Emacs use your X environment's colors instead of its default colors.
 
 ### polybar
 

--- a/wal
+++ b/wal
@@ -279,6 +279,11 @@ export_rofi() {
     x_colors+="rofi.color-urgent: ${rofi_bg}, ${colors[9]}, ${colors[0]}, ${colors[9]}, ${colors[15]}${newline}"
 }
 
+export_emacs() {
+    x_colors+="emacs*background: ${colors[0]}${newline}"
+    x_colors+="emacs*foreground: ${colors[15]}${newline}"
+}
+
 export_plain() {
     printf "%s" "$plain"
     out "export: Exported plain colors"
@@ -290,6 +295,7 @@ export_colors() {
     export_scss      > "${cache_dir}/colors.scss"
     export_firefox   > "${cache_dir}/firefox.css"
     export_rofi
+    export_emacs
     export_plain     > "${cache_dir}/colors"
 }
 


### PR DESCRIPTION
See #40. Adds support for setting `emacs*foreground` and `emacs*background` in the X env, so that users of the `xresources-theme` package for Emacs can use `wal`'s generated colors.