### PR TITLE
Added pid file in place of ps aux 

### DIFF
--- a/wal
+++ b/wal
@@ -332,18 +332,21 @@ cleanup_pid () {
   rm "$pid_file"
 }
 
-kill_old_log_new () {
+kill_old_wal () {
     # Create Cache Dir
     mkdir -p "${cache_dir}/"
+    
     # Kill old 'wal' instances found at $pid_file.
-    if [ -e "$pid_file" ]; then
+    if [[ -f "$pid_file" ]]; then
       old_pid="$(< "${pid_file}")"
       pkill -TERM -P "$old_pid" 2>/dev/null
       kill "$old_pid" 2>/dev/null
     fi
+    
     # Log our pid into the file
     printf "%s" "$$" > "$pid_file"
 }
+
 get_full_path() {
     # Go to the relative PATH.
     if ! cd "${1%/*}"; then
@@ -445,7 +448,7 @@ get_args() {
 
 main () {
     get_args "$@"
-    kill_old_log_new
+    kill_old_wal
 
     get_colors
     send_sequences

--- a/wal
+++ b/wal
@@ -333,14 +333,13 @@ cleanup_pid () {
 }
 
 kill_old_log_new () {
-    # Kill old 'wal' instances.
+    # Kill old 'wal' instances found at $pid_file.
     if [ -e "$pid_file" ]; then
       old_pid="$(< "${pid_file}")"
       pkill -TERM -P "$old_pid" 2>/dev/null
       kill "$old_pid" 2>/dev/null
-      cleanup_pid
     fi
-
+    # Log our pid into the file
     printf "$$" > "$pid_file"
 }
 get_full_path() {

--- a/wal
+++ b/wal
@@ -13,6 +13,7 @@ shopt -s nullglob nocasematch
 
 # Internal variables.
 cache_dir="${HOME}/.cache/wal"
+pid_file="${cache_dir}/wal.pid"
 newline=$'\n'
 color_count=16
 os="$(uname)"
@@ -56,7 +57,7 @@ get_colors() {
             exit 1
         fi
 
-        # Create the cache dir.
+        # Create colorscheme dir.
         mkdir -p "${cache_dir}/schemes"
 
         # Get the current wallpaper.
@@ -304,7 +305,7 @@ export_colors() {
 
 reload_colors() {
     # Source the current sequences
-    sequences="$(< "${HOME}/.cache/wal/sequences")"
+    sequences="$(< "${cache_dir}/sequences")"
 
     # If vte mode was used, remove the problem sequence.
     [[ "$vte" == "on" ]] && sequences="${sequences/??\]708\;\#??????}"
@@ -328,16 +329,16 @@ reload_xrdb() {
 
 # OTHER
 
-kill_old() {
+kill_old_log_new () {
     # Kill old 'wal' instances.
-    pids=($(ps aux | awk '(!/ awk/) && /wal / {print $2}'))
+    if [ -e "$pid_file" ]; then
+      old_pid="$(< "${pid_file}")"
+      pkill -TERM -P "$old_pid" 2>/dev/null
+      kill "$old_pid" 2>/dev/null
+      rm "$pid_file"
+    fi
 
-    for pid in "${pids[@]}"; do
-        if [[ "$pid" != "$$" && "$pid" != "$PPID" ]]; then
-            pkill -TERM -P "$pid" 2>/dev/null
-            kill "$pid" 2>/dev/null
-        fi
-    done
+    printf "$$" > "$pid_file"
 }
 
 get_full_path() {
@@ -441,7 +442,7 @@ get_args() {
 
 main () {
     get_args "$@"
-    kill_old
+    kill_old_log_new
 
     get_colors
     send_sequences
@@ -455,6 +456,8 @@ main () {
 
     # Execute custom script.
     [[ "${external_script[0]}" ]] && bash -c "${external_script[@]}"
+
+
 }
 
 main "$@"

--- a/wal
+++ b/wal
@@ -342,7 +342,7 @@ kill_old_log_new () {
       kill "$old_pid" 2>/dev/null
     fi
     # Log our pid into the file
-    printf "$$" > "$pid_file"
+    printf "%s" "$$" > "$pid_file"
 }
 get_full_path() {
     # Go to the relative PATH.

--- a/wal
+++ b/wal
@@ -333,6 +333,8 @@ cleanup_pid () {
 }
 
 kill_old_log_new () {
+    # Create Cache Dir
+    mkdir -p "${cache_dir}/"
     # Kill old 'wal' instances found at $pid_file.
     if [ -e "$pid_file" ]; then
       old_pid="$(< "${pid_file}")"

--- a/wal
+++ b/wal
@@ -326,8 +326,11 @@ reload_xrdb() {
     xrdb -merge >/dev/null 2>&1 <<< "$x_colors" && \
         out "colors: Merged colors with X env"
 }
-
 # OTHER
+
+cleanup_pid () {
+  rm "$pid_file"
+}
 
 kill_old_log_new () {
     # Kill old 'wal' instances.
@@ -335,12 +338,11 @@ kill_old_log_new () {
       old_pid="$(< "${pid_file}")"
       pkill -TERM -P "$old_pid" 2>/dev/null
       kill "$old_pid" 2>/dev/null
-      rm "$pid_file"
+      cleanup_pid
     fi
 
     printf "$$" > "$pid_file"
 }
-
 get_full_path() {
     # Go to the relative PATH.
     if ! cd "${1%/*}"; then
@@ -457,6 +459,7 @@ main () {
     # Execute custom script.
     [[ "${external_script[0]}" ]] && bash -c "${external_script[@]}"
 
+    cleanup_pid
 
 }
 


### PR DESCRIPTION
Stops from killing any processes with second argument ending in  /wal. 
For example when atom editor is started in the wal directory, the command
 is named like this:
_/usr/share/atom/atom --executed-from=/home/example/wal_
If you were to run wal it would kill your atom instance if it was started before
the previous wal instance as it's PID would appear first. A PID file prevents 
this issue. 