### PR TITLE
Add support for generating GTK themes using Oomox

### DIFF
--- a/wal
+++ b/wal
@@ -17,6 +17,7 @@ newline=$'\n'
 color_count=16
 os="$(uname)"
 
+
 # GENERATE COLORSCHEME
 
 
@@ -245,6 +246,27 @@ export_rofi() {
     x_colors+="rofi.color-urgent: ${rofi_bg}, ${colors[9]}, ${colors[0]}, ${colors[9]}, ${colors[15]}${newline}"
 }
 
+export_oomox() {
+    printf "%s\n" "NAME=wal"
+    printf "%s\n" "BG=${colors[0]/\#}"
+    printf "%s\n" "FG=${colors[15]/\#}"
+    printf "%s\n" "MENU_BG=${colors[0]/\#}"
+    printf "%s\n" "MENU_FG=${colors[15]/\#}"
+    printf "%s\n" "SEL_BG=${colors[3]/\#}"
+    printf "%s\n" "SEL_FG=${colors[15]/\#}"
+    printf "%s\n" "TXT_BG=${colors[3]/\#}"
+    printf "%s\n" "TXT_FG=${colors[15]/\#}"
+    printf "%s\n" "BTN_BG=${colors[1]/\#}"
+    printf "%s\n" "BTN_FG=${colors[15]/\#}"
+    printf "%s\n" "HDR_BTN_BG=${colors[1]/\#}"
+    printf "%s\n" "HDR_BTN_FG=${colors[15]/\#}"
+    printf "%s\n" "GTK3_GENERATE_DARK=False"
+    printf "%s\n" "ROUNDNESS=0"
+    printf "%s\n" "SPACING=3"
+    printf "%s\n" "GRADIENT=0.0"
+    out "export: Exported Oomox colors"
+}
+
 export_plain() {
     printf "%s" "$plain"
     out "export: Exported plain colors"
@@ -255,12 +277,14 @@ export_colors() {
     export_envar     > "${cache_dir}/colors.sh"
     export_scss      > "${cache_dir}/colors.scss"
     export_firefox   > "${cache_dir}/firefox.css"
+    export_oomox     > "${cache_dir}/wal-oomox"
     export_rofi
     export_plain     > "${cache_dir}/colors"
 }
 
 
 # RELOAD COLORSCHEME
+
 
 reload_colors() {
     # Source the current sequences
@@ -276,6 +300,9 @@ reload_colors() {
 reload_env() {
     # Reload i3 if running.
     pgrep i3 && i3-msg reload &
+
+    # Generate GTK Scheme.
+    exists oomox-cli && oomox-cli -o wal-oomox "${cache_dir}/wal-oomox" &
 }
 
 reload_xrdb() {
@@ -286,7 +313,13 @@ reload_xrdb() {
         out "colors: Merged colors with X env"
 }
 
+
 # OTHER
+
+
+exists() {
+    type -p "$1" >/dev/null 2>&1
+}
 
 get_full_path() {
     # Go to the relative PATH.

--- a/wal
+++ b/wal
@@ -302,7 +302,7 @@ reload_env() {
     pgrep i3 && i3-msg reload &
 
     # Generate GTK Scheme.
-    if exists oomox-cli; then
+    if type -p oomox-cli >/dev/null 2>&1; then
         oomox-cli -o wal "${cache_dir}/wal-oomox"
         reload_gtk
     fi
@@ -334,10 +334,6 @@ END
 
 # OTHER
 
-
-exists() {
-    type -p "$1" >/dev/null 2>&1
-}
 
 get_full_path() {
     # Go to the relative PATH.

--- a/wal
+++ b/wal
@@ -254,7 +254,7 @@ export_oomox() {
     printf "%s\n" "MENU_FG=${colors[15]/\#}"
     printf "%s\n" "SEL_BG=${colors[3]/\#}"
     printf "%s\n" "SEL_FG=${colors[15]/\#}"
-    printf "%s\n" "TXT_BG=${colors[3]/\#}"
+    printf "%s\n" "TXT_BG=${colors[0]/\#}"
     printf "%s\n" "TXT_FG=${colors[15]/\#}"
     printf "%s\n" "BTN_BG=${colors[1]/\#}"
     printf "%s\n" "BTN_FG=${colors[15]/\#}"
@@ -302,7 +302,10 @@ reload_env() {
     pgrep i3 && i3-msg reload &
 
     # Generate GTK Scheme.
-    exists oomox-cli && oomox-cli -o wal-oomox "${cache_dir}/wal-oomox" &
+    if exists oomox-cli; then
+        oomox-cli -o wal "${cache_dir}/wal-oomox"
+        reload_gtk
+    fi
 }
 
 reload_xrdb() {
@@ -311,6 +314,21 @@ reload_xrdb() {
     # Merge the colors into the X db so new terminals use them.
     xrdb -merge >/dev/null 2>&1 <<< "$x_colors" && \
         out "colors: Merged colors with X env"
+}
+
+reload_gtk(){
+type -p python2 >/dev/null 2>&1 || return
+
+python2 - <<END
+import sys, gtk
+
+events=gtk.gdk.Event(gtk.gdk.CLIENT_EVENT)
+data=gtk.gdk.atom_intern("_GTK_READ_RCFILES", False)
+events.data_format=8
+events.send_event=True
+events.message_type=data
+events.send_clientmessage_toall()
+END
 }
 
 
@@ -420,7 +438,7 @@ main () {
     set_wallpaper
     export_colors
     reload_xrdb
-    reload_env >/dev/null 2>&1
+    reload_env >/dev/null 2>&1 &
 
     # Set the locale back to the original value.
     export LC_ALL="$sys_locale"


### PR DESCRIPTION
Title.

Closes #27.

TODO:

- [x] Fix conflicts
- [x] Remove `exists()`
- [ ] Drop dependency on `oomox`.

Problems: 

- [ ] `oomox` lags behind wal for 3-5 seconds after colors change.
- [ ] GTK theme reloading requires Python 2.